### PR TITLE
Added get_channel api, change topic bot example

### DIFF
--- a/examples/change_topic.rs
+++ b/examples/change_topic.rs
@@ -1,0 +1,71 @@
+extern crate discord;
+
+use std::env;
+use discord::{Discord, State};
+use discord::model::{Event, Channel};
+
+// A simple "set topic" - bot example.
+// Use by issuing the command "!topic <topic text>" in PM or a visible text channel.
+
+pub fn main() {
+	// log in to the API
+	let discord = Discord::from_bot_token(&env::var("DISCORD_TOKEN").expect("Bad DISCORD_TOKEN")).expect("Login failed");
+
+	// establish websocket and voice connection
+	let (mut connection, ready) = discord.connect().expect("connect failed");
+	println!("[Ready] {} is serving {} servers", ready.user.username, ready.servers.len());
+	let mut state = State::new(ready);
+
+	// receive events forever
+	loop {
+		let event = match connection.recv_event() {
+			Ok(event) => event,
+			Err(err) => {
+				println!("[Warning] Receive error: {:?}", err);
+				if let discord::Error::WebSocket(..) = err {
+					// Handle the websocket connection being dropped
+					let (new_connection, ready) = discord.connect().expect("connect failed");
+					connection = new_connection;
+					state = State::new(ready);
+					println!("[Ready] Reconnected successfully.");
+				}
+				if let discord::Error::Closed(..) = err {
+					break
+				}
+				continue
+			},
+		};
+		state.update(&event);
+
+		match event {
+			Event::MessageCreate(message) => {
+				use std::ascii::AsciiExt;
+				// safeguard: stop if the message is from us
+				if message.author.id == state.user().id {
+					continue
+				}
+
+				// reply to a command if there was one
+				let mut split = message.content.split(" ");
+				let first_word = split.next().unwrap_or("");
+				let argument = split.next().unwrap_or("");
+
+				if first_word.eq_ignore_ascii_case("!topic") {
+            let ch_info = discord.get_channel(&message.channel_id);
+            if ch_info.is_ok() {
+                match ch_info.unwrap() {
+                    Channel::Public(channel) => {
+                        let _ = discord.edit_channel(&message.channel_id,
+                                                      Some(&channel.name),
+                                                      Some(channel.position),
+                                                      Some(argument));
+                    },
+                    _ => {},
+                }
+            }
+				}
+			},
+			_ => {}, // discard other events
+		}
+	}
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -202,6 +202,13 @@ impl Discord {
 		Channel::decode(try!(serde_json::from_reader(response)))
 	}
 
+  /// Get channel information by channel id.
+  pub fn get_channel(&self, channel: &ChannelId) -> Result<Channel> {
+    let response = try!(self.request(||
+    self.client.get(&format!("{}/channels/{}", API_BASE, channel.0))));
+    Channel::decode(try!(serde_json::from_reader(response)))
+  }
+
 	/// Edit a channel's name.
 	pub fn edit_channel(&self, channel: &ChannelId,
 		name: Option<&str>,


### PR DESCRIPTION
Please add this, otherwise there is not normal way to use "edit_channel" since we don't know other information of the channel, we first out to know it somehow thus I've implemented "get_channel" api of [discord](https://discordapp.com/developers/docs/resources/channel#get-channel).
