### PR TITLE
Add function to get a single message by ID

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -233,6 +233,12 @@ impl Discord {
 		Ok(())
 	}
 
+	/// Get a single message by ID from a given channel.
+	pub fn get_message(&self, channel: ChannelId, message: MessageId) -> Result<Message> {
+		let response = try!(self.request(|| self.client.get(&format!("{}/channels/{}/messages/{}", API_BASE, channel.0, message.0))));
+		Message::decode(try!(serde_json::from_reader(response)))
+	}
+
 	/// Get messages in the backlog for a given channel.
 	///
 	/// The `what` argument should be one of the options in the `GetMessages`


### PR DESCRIPTION
Would `get_single_message` be more appropriate than `get_message` because of the potential confusion with `get_messages`?
