### PR TITLE
EmbedBuilder fixes

### DIFF
--- a/src/builders.rs
+++ b/src/builders.rs
@@ -219,14 +219,14 @@ impl EmbedBuilder {
 		EmbedBuilder(self.0.insert("footer", f(EmbedFooterBuilder(ObjectBuilder::new())).0.build()))
 	}
 
-	/// Add "image information". See the `EmbedImageBuilder` struct for the editable fields.
+	/// Add "image information". Url must point to image's web address.
 	pub fn image(self, url: &str) -> Self {
 		EmbedBuilder(self.0.insert("image", ObjectBuilder::new().insert("url", url).build()))
 	}
 
-	/// Add "thumbnail information". See the `EmbedThumbnailBuilder` struct for the editable fields.
+	/// Add "thumbnail information". Url must point to image's web address.
 	pub fn thumbnail(self, url: &str) -> Self {
-		EmbedBuilder(self.0.insert("image", ObjectBuilder::new().insert("url", url).build()))
+		EmbedBuilder(self.0.insert("thumbnail", ObjectBuilder::new().insert("url", url).build()))
 	}
 
 	/// Add "author information". See the `EmbedAuthorBuilder` struct for the editable fields.


### PR DESCRIPTION
Fixed wrong comments about non-existing entities.
EmbedBuilder's thum…bnail method now works correctly and sends thumbnail instead of an image.

The work is based on my [comment](https://github.com/SpaceManiac/discord-rs/commit/4bfe850dd2d9cf365a68ac47c31081a0e297e388#diff-b4aea3e418ccdb71239b96952d9cddb6R1236).