### PR TITLE
Fix typos in embed builders.

### DIFF
--- a/src/builders.rs
+++ b/src/builders.rs
@@ -219,14 +219,14 @@ impl EmbedBuilder {
 		EmbedBuilder(self.0.insert("footer", f(EmbedFooterBuilder(ObjectBuilder::new())).0.build()))
 	}
 
-	/// Add "image information". See the `EmbedImageBuilder` struct for the editable fields.
+	/// Add "source url of image". Only supports http(s).
 	pub fn image(self, url: &str) -> Self {
 		EmbedBuilder(self.0.insert("image", ObjectBuilder::new().insert("url", url).build()))
 	}
 
-	/// Add "thumbnail information". See the `EmbedThumbnailBuilder` struct for the editable fields.
+	/// Add "source url of thumbnail". Only supports http(s).
 	pub fn thumbnail(self, url: &str) -> Self {
-		EmbedBuilder(self.0.insert("image", ObjectBuilder::new().insert("url", url).build()))
+		EmbedBuilder(self.0.insert("thumbnail", ObjectBuilder::new().insert("url", url).build()))
 	}
 
 	/// Add "author information". See the `EmbedAuthorBuilder` struct for the editable fields.


### PR DESCRIPTION
Comments for `EmbedBuilder::image` and `EmbedBuilder::thumbnail` were wrong,
and `thumbnail()` contained a string literal `"image"` that should have been
`"thumbnail"`. Apologies.