### PR TITLE
Hyper 0.10 and openssl 0.9.

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -19,7 +19,7 @@ voice = ["opus", "sodiumoxide"]
 hyper = { version = "0.10", default-features = false }
 hyper-native-tls = "0.2.2"
 serde_json = "0.8"
-websocket = { git = "https://github.com/avadacatavra/rust-websocket", branch = "hyper-bump" }
+websocket = { git = "https://github.com/ArtemGr/rust-websocket", branch = "hyper-bump" }
 bitflags = "0.7"
 byteorder = "0.5"
 time = "0.1"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,7 +16,8 @@ default = ["voice"]
 voice = ["opus", "sodiumoxide"]
 
 [dependencies]
-hyper = "0.9"
+hyper = { version = "0.10", default-features = false }
+hyper-rustls = "0.3.2"
 serde_json = "0.8"
 websocket = "0.17"
 bitflags = "0.7"
@@ -26,13 +27,10 @@ log = "0.3"
 base64-rs = "0.1.1"
 flate2 = "0.2.14"
 opus = { version = "0.2", optional = true }
+multipart = { version = "0.9", default-features = false, features = ["client", "mock"] }
+mime = "0.2.2"
 
 [dependencies.sodiumoxide]
 version = "0.0.12"
 default-features = false
 optional = true
-
-[dependencies.multipart]
-version = "0.8"
-default-features = false
-features = ["hyper", "client"]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -17,9 +17,9 @@ voice = ["opus", "sodiumoxide"]
 
 [dependencies]
 hyper = { version = "0.10", default-features = false }
-hyper-rustls = "0.3.2"
+hyper-native-tls = "0.2.2"
 serde_json = "0.8"
-websocket = "0.17"
+websocket = { git = "https://github.com/avadacatavra/rust-websocket", branch = "hyper-bump" }
 bitflags = "0.7"
 byteorder = "0.5"
 time = "0.1"


### PR DESCRIPTION
Some of the libraries I need are using openssl 0.9, so I've baked a version of discord-rs which works with the newer openssl-sys.

To untangle the older openssl I had to change the multipart code in `fn send_file`. Haven't tested it (my bot's not using that function yet) but it's based on something I use myself in another place.

Had to patch rust-websocket as well.

My bot's now working NP on the upgraded discord-rs so the patch got at least that bit of testing.