### PR TITLE
Added role management apis [work in progress]

### DIFF
--- a/src/builders.rs
+++ b/src/builders.rs
@@ -38,6 +38,9 @@ builder! {
 	/// Patch content for the `edit_user_profile` call.
 	EditUserProfile(ObjectBuilder);
 
+	/// Patch content for the `edit_role` call.
+	EditRole(ObjectBuilder);
+
 	/// Patch content for the `send_embed` call.
 	EmbedBuilder(ObjectBuilder);
 
@@ -185,6 +188,33 @@ impl EditUserProfile {
 	/// Edit the user's avatar. Use `None` to remove the avatar.
 	pub fn avatar(self, icon: Option<&str>) -> Self {
 		EditUserProfile(self.0.insert("avatar", icon))
+	}
+}
+
+impl EditRole {
+	/// Edit the role's name. Supply the empty string to remove a name.
+	pub fn name(self, name: &str) -> Self {
+		EditRole(self.0.insert("name", name))
+	}
+
+	/// Edit the role's permissions.
+	pub fn permissions(self, permissions: Permissions) -> Self {
+		EditRole(self.0.insert("permissions", permissions.bits()))
+	}
+
+	/// Edit the role's color.
+	pub fn color(self, color: u64) -> Self {
+		EditRole(self.0.insert("color", color))
+	}
+
+	/// Edit the role's hoist status (whether the role should be displayed separately in the sidebar).
+	pub fn hoist(self, hoist: bool) -> Self {
+		EditRole(self.0.insert("hoist", hoist))
+	}
+	
+	/// Edit the role's mentionable status.
+	pub fn mentionable(self, mentionable: bool) -> Self {
+		EditRole(self.0.insert("mentionable", mentionable))
 	}
 }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -869,26 +869,26 @@ impl Discord {
 	/// Create a new role on a server.
 	pub fn create_role(&self, server: ServerId, name: Option<&str>, permissions: Option<Permissions>,
 	                   color: Option<u64>, hoist: Option<bool>, mentionable: Option<bool>) -> Result<Role> {
-			let mut map = ObjectBuilder::new();
-			if let Some(name) = name {
-				map = map.insert("name", name);
-			}
-			if let Some(permissions) = permissions {
-				map = map.insert("permissions", permissions.bits());
-			}
-			if let Some(color) = color {
-				map = map.insert("color", color);
-			}
-			if let Some(hoist) = hoist {
-				map = map.insert("hoist", hoist);
-			}
-			if let Some(mentionable) = mentionable {
-				map = map.insert("mentionable", mentionable);
-			}
-			let map = map.build();
-			let body = try!(serde_json::to_string(&map));
-			let response = request!(self, post(body), "/guilds/{}/roles", server);
-			Role::decode(try!(serde_json::from_reader(response)))
+		let mut map = ObjectBuilder::new();
+		if let Some(name) = name {
+			map = map.insert("name", name);
+		}
+		if let Some(permissions) = permissions {
+			map = map.insert("permissions", permissions.bits());
+		}
+		if let Some(color) = color {
+			map = map.insert("color", color);
+		}
+		if let Some(hoist) = hoist {
+			map = map.insert("hoist", hoist);
+		}
+		if let Some(mentionable) = mentionable {
+			map = map.insert("mentionable", mentionable);
+		}
+		let map = map.build();
+		let body = try!(serde_json::to_string(&map));
+		let response = request!(self, post(body), "/guilds/{}/roles", server);
+		Role::decode(try!(serde_json::from_reader(response)))
 	}
 
 	/// Remove specified role from a server.


### PR DESCRIPTION
This patch adds support for role management APIs: create, edit, remove, reorder roles; add and remove user from role.

It's almost fully complete, apart from one compiler issue in `reorder_roles`. I couldn't figure what exactly goes wrong in there, so the code is commented and I'm up for any advice. Otherwise, I can just remove that method.