### PR TITLE
Add get_current_user method to client

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -891,6 +891,12 @@ impl Discord {
 		Ok(vec)
 	}
 
+	/// Get the logged-in user's profile.
+	pub fn get_current_user(&self) -> Result<CurrentUser> {
+		let response = request!(self, get, "/users/@me");
+		CurrentUser::decode(try!(serde_json::from_reader(response)))
+	}
+
 	/// Edit the logged-in bot or user's profile. See `EditProfile` for editable fields.
 	///
 	/// Usable for bot and user accounts. Only allows updating the username and


### PR DESCRIPTION
Currently the only way to do this is to call `edit_user` with an empty closure, which feels hacky, or call `get_member` on a server the client user is already part of. However, if the user isn't currently part of any servers, this won't be possible.