### PR TITLE
published from_token_raw

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -207,7 +207,10 @@ impl Discord {
 		Ok(discord)
 	}
 
-	fn from_token_raw(token: String) -> Discord {
+	/// Login with raw token.
+	///
+	/// Consider using from_user_token or from_bot_token instead.
+	pub fn from_token_raw(token: String) -> Discord {
 		Discord {
 			rate_limits: RateLimits::default(),
 			client: hyper::Client::new(),
@@ -219,7 +222,7 @@ impl Discord {
 	///
 	/// The token will automatically be prefixed with "Bot ".
 	pub fn from_bot_token(token: &str) -> Result<Discord> {
-		Ok(Discord::from_token_raw(format!("Bot {}", token.trim())))
+		Ok(Discord::from_token_raw("Bot ".to_string() + token.trim()))
 	}
 
 	/// Log in as a user account using the given authentication token.

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -222,7 +222,7 @@ impl Discord {
 	///
 	/// The token will automatically be prefixed with "Bot ".
 	pub fn from_bot_token(token: &str) -> Result<Discord> {
-		Ok(Discord::from_token_raw("Bot ".to_string() + token.trim()))
+		Ok(Discord::from_token_raw(format!("Bot {}", token.trim())))
 	}
 
 	/// Log in as a user account using the given authentication token.


### PR DESCRIPTION
*Warning: I am a Rust beginner.*

from_user_token trims and converts token to a owned String. Imagine I already made sure it's trimmed and that it is a `String`.. then it's doing all for nothing.

Publishing `from_token_raw` might make this more efficient :thinking: 