### PR TITLE
Implemented FromStr for models that had similer functionality

### DIFF
--- a/src/model.rs
+++ b/src/model.rs
@@ -52,7 +52,7 @@ macro_rules! string_decode_using_serial_name {
 		impl FromStr for $typ {
 			type Err = Error;
 			fn from_str(s: &str) -> Result<Self> {
-				Self::from_name(s).ok_or(Error::Decode("Unexpected String", Value::String(s.into())))
+				Self::from_name(s).ok_or(Error::Other(concat!("Unable to parse string into " , stringify!($typ))))
 			}
 		}
 	}

--- a/src/model.rs
+++ b/src/model.rs
@@ -47,13 +47,13 @@ macro_rules! serial_decode {
 	}
 }
 
-macro_rules! string_decode_with_serial_name {
+macro_rules! string_decode_using_serial_name {
 	($typ:ident) => {
 		impl FromStr for $typ {
 			type Err = Error;
-					fn from_str(s: &str) -> Result<Self> {
+			fn from_str(s: &str) -> Result<Self> {
 				Self::from_name(s).ok_or(Error::Decode("Unexpected String", Value::String(s.into())))
-					}
+			}
 		}
 	}
 }

--- a/src/model.rs
+++ b/src/model.rs
@@ -224,7 +224,7 @@ serial_names! { ChannelType;
 	Text, "text";
 	Voice, "voice";
 }
-string_decode_with_serial_name!(ChannelType);
+string_decode_using_serial_name!(ChannelType);
 serial_numbers! { ChannelType;
 	Text, 0;
 	Private, 1;
@@ -854,7 +854,7 @@ serial_names! { OnlineStatus;
 	Online, "online";
 	Idle, "idle";
 }
-string_decode_with_serial_name!(OnlineStatus);
+string_decode_using_serial_name!(OnlineStatus);
 
 /// A type of game being played.
 #[derive(Copy, Clone, Hash, Eq, PartialEq, Debug)]

--- a/src/model.rs
+++ b/src/model.rs
@@ -2,6 +2,7 @@
 #![allow(missing_docs)]
 
 use std::fmt;
+use std::str::FromStr;
 use std::borrow::Cow;
 use std::collections::BTreeMap;
 
@@ -42,6 +43,17 @@ macro_rules! serial_decode {
 			pub fn decode(value: Value) -> Result<Self> {
 				serde(value)
 			}
+		}
+	}
+}
+
+macro_rules! string_decode_with_serial_name {
+	($typ:ident) => {
+		impl FromStr for $typ {
+			type Err = Error;
+					fn from_str(s: &str) -> Result<Self> {
+				Self::from_name(s).ok_or(Error::Decode("Unexpected String", Value::String(s.into())))
+					}
 		}
 	}
 }
@@ -212,6 +224,7 @@ serial_names! { ChannelType;
 	Text, "text";
 	Voice, "voice";
 }
+string_decode_with_serial_name!(ChannelType);
 serial_numbers! { ChannelType;
 	Text, 0;
 	Private, 1;
@@ -841,6 +854,7 @@ serial_names! { OnlineStatus;
 	Online, "online";
 	Idle, "idle";
 }
+string_decode_with_serial_name!(OnlineStatus);
 
 /// A type of game being played.
 #[derive(Copy, Clone, Hash, Eq, PartialEq, Debug)]


### PR DESCRIPTION
The two are ChannelType and OnlineStatus.  

This is to close issue #125.  I don't think there was any from_str implementation before, but there was from_name, which would make sense as it gives context to the serialization process.  I implemented a macro which will cover the changes in the model module.  It however requires serial_name to function.  I consider this to make more sense being placed in the model instead of directly in the serial_names! macro, in addition to making it more clear as to the extra use statement which would need to be in model regardless.