### PR TITLE
Updated version of pull request #100 to add role api

### DIFF
--- a/src/builders.rs
+++ b/src/builders.rs
@@ -38,6 +38,9 @@ builder! {
 	/// Patch content for the `edit_user_profile` call.
 	EditUserProfile(ObjectBuilder);
 
+	/// Patch content for the `edit_role` call.
+	EditRole(ObjectBuilder);
+
 	/// Patch content for the `send_embed` call.
 	EmbedBuilder(ObjectBuilder);
 
@@ -185,6 +188,33 @@ impl EditUserProfile {
 	/// Edit the user's avatar. Use `None` to remove the avatar.
 	pub fn avatar(self, icon: Option<&str>) -> Self {
 		EditUserProfile(self.0.insert("avatar", icon))
+	}
+}
+
+impl EditRole {
+	/// Edit the role's name. Supply the empty string to remove a name.
+	pub fn name(self, name: &str) -> Self {
+		EditRole(self.0.insert("name", name))
+	}
+
+	/// Edit the role's permissions.
+	pub fn permissions(self, permissions: Permissions) -> Self {
+		EditRole(self.0.insert("permissions", permissions.bits()))
+	}
+
+	/// Edit the role's color.
+	pub fn color(self, color: u64) -> Self {
+		EditRole(self.0.insert("color", color))
+	}
+
+	/// Edit the role's hoist status (whether the role should be displayed separately in the sidebar).
+	pub fn hoist(self, hoist: bool) -> Self {
+		EditRole(self.0.insert("hoist", hoist))
+	}
+	
+	/// Edit the role's mentionable status.
+	pub fn mentionable(self, mentionable: bool) -> Self {
+		EditRole(self.0.insert("mentionable", mentionable))
 	}
 }
 

--- a/src/builders.rs
+++ b/src/builders.rs
@@ -66,7 +66,7 @@ builder! {
 	EditUserProfile(Object);
 
 	/// Patch content for the `edit_role` call.
-	EditRole(ObjectBuilder);
+	EditRole(Object);
 
 	/// Patch content for the `send_embed` call.
 	EmbedBuilder(Object);
@@ -226,27 +226,27 @@ impl EditUserProfile {
 impl EditRole {
 	/// Edit the role's name. Supply the empty string to remove a name.
 	pub fn name(self, name: &str) -> Self {
-		EditRole(self.0.insert("name", name))
+		set!(self, "name", name)
 	}
 
 	/// Edit the role's permissions.
 	pub fn permissions(self, permissions: Permissions) -> Self {
-		EditRole(self.0.insert("permissions", permissions.bits()))
+		set!(self, "permissions", permissions)
 	}
 
-	/// Edit the role's color.
+	/// Edit the role's color. Set to zero for default.
 	pub fn color(self, color: u64) -> Self {
-		EditRole(self.0.insert("color", color))
+		set!(self, "color", color)
 	}
 
 	/// Edit the role's hoist status (whether the role should be displayed separately in the sidebar).
 	pub fn hoist(self, hoist: bool) -> Self {
-		EditRole(self.0.insert("hoist", hoist))
+		set!(self, "hoist", hoist)
 	}
-	
-	/// Edit the role's mentionable status.
+
+	/// Edit the role's mentionability, if the role can be mentioned.
 	pub fn mentionable(self, mentionable: bool) -> Self {
-		EditRole(self.0.insert("mentionable", mentionable))
+		set!(self, "mentionable", mentionable)
 	}
 }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -869,26 +869,26 @@ impl Discord {
 	/// Create a new role on a server.
 	pub fn create_role(&self, server: ServerId, name: Option<&str>, permissions: Option<Permissions>,
 	                   color: Option<u64>, hoist: Option<bool>, mentionable: Option<bool>) -> Result<Role> {
-			let mut map = ObjectBuilder::new();
-			if let Some(name) = name {
-				map = map.insert("name", name);
-			}
-			if let Some(permissions) = permissions {
-				map = map.insert("permissions", permissions.bits());
-			}
-			if let Some(color) = color {
-				map = map.insert("color", color);
-			}
-			if let Some(hoist) = hoist {
-				map = map.insert("hoist", hoist);
-			}
-			if let Some(mentionable) = mentionable {
-				map = map.insert("mentionable", mentionable);
-			}
-			let map = map.build();
-			let body = try!(serde_json::to_string(&map));
-			let response = request!(self, post(body), "/guilds/{}/roles", server);
-			Role::decode(try!(serde_json::from_reader(response)))
+		let mut map = ObjectBuilder::new();
+		if let Some(name) = name {
+			map = map.insert("name", name);
+		}
+		if let Some(permissions) = permissions {
+			map = map.insert("permissions", permissions.bits());
+		}
+		if let Some(color) = color {
+			map = map.insert("color", color);
+		}
+		if let Some(hoist) = hoist {
+			map = map.insert("hoist", hoist);
+		}
+		if let Some(mentionable) = mentionable {
+			map = map.insert("mentionable", mentionable);
+		}
+		let map = map.build();
+		let body = try!(serde_json::to_string(&map));
+		let response = request!(self, post(body), "/guilds/{}/roles", server);
+		Role::decode(try!(serde_json::from_reader(response)))
 	}
 
 	/// Remove specified role from a server.

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -882,6 +882,14 @@ impl Discord {
 		Role::decode(try!(serde_json::from_reader(response)))
 	}
 
+	/// Create a new role on a server.
+	pub fn create_role_from_builder<F: FnOnce(EditRole) -> EditRole>(&self, server: ServerId, f: F) -> Result<Role> {
+		let map = EditRole::__build(f);
+		let body = try!(serde_json::to_string(&map));
+		let response = request!(self, post(body), "/guilds/{}/roles", server);
+		Role::decode(try!(serde_json::from_reader(response)))
+	}
+
 	/// Modify a role on a server.
 	pub fn edit_role<F: FnOnce(EditRole) -> EditRole>(&self, server: ServerId, role: RoleId, f: F) -> Result<Role> {
 		let map = EditRole::__build(f);

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -846,6 +846,16 @@ impl Discord {
 		self.edit_member(server, user, |m| m.roles(roles))
 	}
 
+    /// Add a role to a member of a server.
+    pub fn add_member_role(&self, server: ServerId, user: UserId, role: RoleId) -> Result<()> {
+		check_empty(request!(self, put, "/guilds/{}/members/{}/roles/{}", server, user, role))
+    }
+
+    /// Remove a role for a member of a server.
+    pub fn remove_member_role(&self, server: ServerId, user: UserId, role: RoleId) -> Result<()> {
+		check_empty(request!(self, delete, "/guilds/{}/members/{}/roles/{}", server, user, role))
+    }
+
 	/// Edit member information, including roles, nickname, and voice state.
 	///
 	/// See the `EditMember` struct for the editable fields.


### PR DESCRIPTION
I started with pull request #100 and updated it to work with the current version of discord.  I also figured out a way to implement role reordering that seems to work quite well.  

I am have added also added a create_role that takes in the edit builder.  I think that we should consider making it named something other then edit builder.