### PR TITLE
Fix error return due to incomplete fields in USER_UPDATE events

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -928,7 +928,7 @@ impl Discord {
 		// First, get the current profile, so that providing username and avatar is optional.
 		let response = request!(self, get, "/users/@me");
 		let user: CurrentUser = try!(from_reader(response));
-		if user.bot {
+		if user.bot == true {
 			return Err(Error::Other("Cannot call edit_user_profile on a bot account"))
 		}
 		let mut map = Object::new();

--- a/src/state.rs
+++ b/src/state.rs
@@ -89,7 +89,9 @@ impl State {
 	pub fn update(&mut self, event: &Event) {
 		match *event {
 			Event::Ready(ref ready) => *self = State::new(ready.clone()),
-			Event::UserUpdate(ref user) => self.user = user.clone(),
+			Event::UserUpdate(ref user) => {
+				self.user.update_from(user);
+			},
 			Event::UserNoteUpdate(user_id, ref note) => {
 				if let Some(notes) = self.notes.as_mut() {
 					if note.is_empty() {


### PR DESCRIPTION
Discord sends incomplete CurrentUser structures for USER_UPDATE events in certain cases. This change makes most of the fields `Option`s, and changes the state logic to retain the prior value of the field if it is missing in the update.

I've left id, username, and discriminator alone as I suspect these are the most commonly used fields (and thus would have the most compatibility impact if changed), and they do seem to be present, at least for the messages I've seen so far.

Closes #139.