### PR TITLE
Fix Playing presence

### DIFF
--- a/src/connection.rs
+++ b/src/connection.rs
@@ -153,7 +153,7 @@ impl Connection {
 		};
 		let game = match game {
 			Some(Game {kind: GameType::Streaming, url: Some(url), name}) => json! {{ "type": GameType::Streaming, "url": url, "name": name }},
-			Some(game) => json! {{ "name": game.name }},
+			Some(game) => json! {{ "name": game.name, "type": GameType::Playing }},
 			None => json!(null),
 		};
 		let msg = json! {{


### PR DESCRIPTION
`type` is a required field, if you don't pass it, it will silently fail.