### PR TITLE
Add field Emoji::animated

### DIFF
--- a/src/model.rs
+++ b/src/model.rs
@@ -1000,6 +1000,7 @@ pub struct Emoji {
 	pub name: String,
 	pub managed: bool,
 	pub require_colons: bool,
+	pub animated: bool,
 	pub roles: Vec<RoleId>,
 }
 serial_decode!(Emoji);


### PR DESCRIPTION
This commit adds the `animated` field to `discord::model::Emoji` to match the corresponding field described in the [Discord documentation](https://discordapp.com/developers/docs/resources/emoji#emoji-object-emoji-structure).