### PR TITLE
Add Message.referenced_message

### DIFF
--- a/src/model.rs
+++ b/src/model.rs
@@ -847,6 +847,7 @@ pub struct Message {
 	pub attachments: Vec<Attachment>,
 	/// Follows OEmbed standard
 	pub embeds: Vec<Value>,
+	pub referenced_message: Option<Box<Message>>,
 
 	pub flags: MessageFlags,
 }


### PR DESCRIPTION
See https://discord.com/developers/docs/resources/channel#message-object-message-structure. Set for messages that are replying to another message, for example.