### PR TITLE
Fix get_server_members

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -933,7 +933,7 @@ impl Discord {
 	}
 
 	/// Gets the list of a specific server's members.
-	pub fn get_server_members(&self, server_id: ServerId) -> Result<Vec<User>> {
+	pub fn get_server_members(&self, server_id: ServerId) -> Result<Vec<Member>> {
 		let response = request!(self, get, "/guilds/{}/members", server_id);
 		from_reader(response)
 	}


### PR DESCRIPTION
get_server_members was giving
```
Err(
    Json(
        Error("missing field `id`", line: 1, column: 383),
    ),
)
```
Since the api returned Members instead of users.