### PR TITLE
Add missing channel definitions

### DIFF
--- a/src/connection.rs
+++ b/src/connection.rs
@@ -34,7 +34,7 @@ pub struct ConnectionBuilder<'a> {
 	base_url: String,
 	token: &'a str,
 
-	large_threshold: Option<u32>,
+	//large_threshold: Option<u32>,
 	shard: Option<[u8; 2]>,
 	intents: Option<Intents>,
 	// TODO: presence
@@ -45,7 +45,7 @@ impl<'a> ConnectionBuilder<'a> {
 		ConnectionBuilder {
 			base_url,
 			token,
-			large_threshold: None,
+			//large_threshold: None,
 			shard: None,
 			intents: None,
 		}

--- a/src/model.rs
+++ b/src/model.rs
@@ -247,6 +247,18 @@ pub enum ChannelType {
 	News,
 	///
 	Store,
+	/// A temporary sub-channel within a news channel
+	NewsThread,
+	/// A temporary sub-channel within a group channel
+	PublicThread,
+	/// A temporary sub-channel within a group channel, limited to those who are invited or have MANAGE_THREADS
+	PrivateThread,
+	/// A voice channel for hosting events
+	StageVoice,
+	/// A channel which contains a list of servers
+	Directory,
+	///	A channel which exclusively contains threads
+	Forum,
 }
 
 serial_use_mapping!(ChannelType, numeric);
@@ -258,6 +270,12 @@ serial_names! { ChannelType;
 	Category, "category";
 	News, "news";
 	Store, "store";
+	NewsThread, "news_thread";
+	PublicThread, "public_thread";
+	PrivateThread, "private_thread";
+	StageVoice, "stage_voice";
+	Directory, "directory";
+	Forum, "forum";
 }
 string_decode_using_serial_name!(ChannelType);
 serial_numbers! { ChannelType;
@@ -268,6 +286,12 @@ serial_numbers! { ChannelType;
 	Category, 4;
 	News, 5;
 	Store, 6;
+	NewsThread, 10;
+	PublicThread, 11;
+	PrivateThread, 12;
+	StageVoice, 13;
+	Directory, 14;
+	Forum, 15;
 }
 
 /// A channel category.


### PR DESCRIPTION
New channel types cause issues with logging in when the bot or user account exists in a server containing either of the following:

- Guild Stage Voice
- Guild Forum

I've added those and these others, which I have not encountered on any of my own accounts yet but expect to cause a similar error sooner or later:

- Guild News Thread
- Guild Public Thread
- Guild Private Thread
- Guild Directory