### PR TITLE
Fix create_channel()

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -324,7 +324,7 @@ impl Discord {
 	) -> Result<Channel> {
 		let map = json! {{
 			"name": name,
-			"type": kind.number(),
+			"type": kind.num(),
 		}};
 		let body = serde_json::to_string(&map)?;
 		let response = request!(self, post(body), "/guilds/{}/channels", server);

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -324,7 +324,7 @@ impl Discord {
 	) -> Result<Channel> {
 		let map = json! {{
 			"name": name,
-			"type": kind.name(),
+			"type": kind.number(),
 		}};
 		let body = serde_json::to_string(&map)?;
 		let response = request!(self, post(body), "/guilds/{}/channels", server);


### PR DESCRIPTION
Otherwise, we have this:

```rust
Status(
    BadRequest,
    Some(
        Object {
            "type": Array [
                String("Value \"text\" is not int."),
            ],
        },
    ),
)
```